### PR TITLE
Fix: Add `Basic` prefix to `authenticateWithHTTPBasicAuth()`

### DIFF
--- a/.changesets/1717563115-fbwqo.patch.md
+++ b/.changesets/1717563115-fbwqo.patch.md
@@ -1,0 +1,1 @@
+Fix: Add `Basic` prefix to `authenticateWithHTTPBasicAuth()`

--- a/src/request.ts
+++ b/src/request.ts
@@ -20,9 +20,9 @@ export class OAuth2RequestContext {
 	}
 
 	public authenticateWithHTTPBasicAuth(clientId: string, clientSecret: string): void {
-		const authorizationHeader = base64.encode(
+		const authorizationHeader = `Basic ${base64.encode(
 			new TextEncoder().encode(`${clientId}:${clientSecret}`)
-		);
+		)}`;
 		this.headers.set("Authorization", authorizationHeader);
 	}
 


### PR DESCRIPTION
#1